### PR TITLE
shipping destination api modify

### DIFF
--- a/src/main/java/sphabucks/domain/shipping/model/Destination.java
+++ b/src/main/java/sphabucks/domain/shipping/model/Destination.java
@@ -23,14 +23,9 @@ public class Destination extends BaseTimeEntity {
     @Column(nullable = false)
     private String recipient;   // 받는 분
     @Column(nullable = false)
-    private String zipCode;     //우편 번호
-    @Column(nullable = false)
     private String defaultAddress;  // 기본 주소
     @Column(nullable = false)
-    private String detailAddress;   // 상세 주소
-    @Column(nullable = false)
     private String phoneNum;    // 연락처 1
-    private String phoneNum2;   // 연락처 2
     private String content;     // 배송 메모
 
     private boolean defaultDestination; // 기본(대표) 배송지

--- a/src/main/java/sphabucks/domain/shipping/service/DestinationImplement.java
+++ b/src/main/java/sphabucks/domain/shipping/service/DestinationImplement.java
@@ -34,21 +34,19 @@ public class DestinationImplement implements IDestinationService {
 
         // 새로운 배송지를 등록하는 경우
         if (newDefaultDestination) {
-            Destination originalDefaultDestination =
-                    iDestinationRepo.findByUserIdAndDefaultDestinationIsTrue(user.getId())
-                            .orElseThrow(() -> new BusinessException(ErrorCode.DESTINATION_BASIC_NOT_EXISTS, ErrorCode.DESTINATION_BASIC_NOT_EXISTS.getDescription()));
-            originalDefaultDestination.setDefaultDestination(false);
+            if (iDestinationRepo.findByUserIdAndDefaultDestinationIsTrue(user.getId()).isPresent()) {
+                Destination originalDefaultDestination =
+                        iDestinationRepo.findByUserIdAndDefaultDestinationIsTrue(user.getId()).get();
+                originalDefaultDestination.setDefaultDestination(false);
+            }
         }
 
         iDestinationRepo.save(Destination.builder()
                 .user(user)
                 .name(requestDestination.getName())
                 .recipient(requestDestination.getRecipient())
-                .zipCode(requestDestination.getZipCode())
                 .defaultAddress(requestDestination.getDefaultAddress())
-                .detailAddress(requestDestination.getDetailAddress())
                 .phoneNum(requestDestination.getPhoneNum())
-                .phoneNum2(requestDestination.getPhoneNum2())
                 .content(requestDestination.getContent())
                 .defaultDestination(newDefaultDestination)
                 .build());
@@ -75,11 +73,8 @@ public class DestinationImplement implements IDestinationService {
 
         destination.setName(requestDestination.getName());
         destination.setRecipient(requestDestination.getRecipient());
-        destination.setZipCode(requestDestination.getZipCode());
         destination.setDefaultAddress(requestDestination.getDefaultAddress());
-        destination.setDetailAddress(requestDestination.getDetailAddress());
         destination.setPhoneNum(requestDestination.getPhoneNum());
-        destination.setPhoneNum2(requestDestination.getPhoneNum2());
         destination.setContent(requestDestination.getContent());
         destination.setDefaultDestination(requestDestination.getDefaultDestination());
     }
@@ -107,11 +102,8 @@ public class DestinationImplement implements IDestinationService {
                 return_value.add(ResponseDestinationSummary.builder()
                     .name(destination.getName())
                     .recipient(destination.getRecipient())
-                    .zipCode(destination.getZipCode())
                     .defaultAddress(destination.getDefaultAddress())
-                    .detailAddress(destination.getDetailAddress())
                     .phoneNum(destination.getPhoneNum())
-                    .phoneNum2(destination.getPhoneNum2())
                     .content(destination.getContent())
                     .build()));
 

--- a/src/main/java/sphabucks/domain/shipping/vo/RequestDestination.java
+++ b/src/main/java/sphabucks/domain/shipping/vo/RequestDestination.java
@@ -7,11 +7,8 @@ public class RequestDestination {
 
     private String name;    // 주소 별칭
     private String recipient;   // 받는 분
-    private String zipCode;     //우편 번호
     private String defaultAddress;  // 기본 주소
-    private String detailAddress;   // 상세 주소
     private String phoneNum;    // 연락처 1
-    private String phoneNum2;   // 연락처 2
     private String content;     // 배송 메모
 
     private Boolean defaultDestination; // 기본 배송지로 저장합니다. 체크 유무

--- a/src/main/java/sphabucks/domain/shipping/vo/ResponseDestinationSummary.java
+++ b/src/main/java/sphabucks/domain/shipping/vo/ResponseDestinationSummary.java
@@ -11,11 +11,8 @@ public class ResponseDestinationSummary {
 
     private String name;    // 주소 별칭
     private String recipient;   // 받는 분
-    private String zipCode;     //우편 번호
     private String defaultAddress;  // 기본 주소
-    private String detailAddress;   // 상세 주소
     private String phoneNum;    // 연락처 1
-    private String phoneNum2;   // 연락처 2
     private String content;     // 배송 메모
 
 }


### PR DESCRIPTION
1. 우편번호 삭제
2. 상세주소 삭제
3. 연락처2 삭제

현재 수정한거 없는 서버 swagger 에서도 에러 처리가 잘못 되있어서 add 메서드 작동 안됩니다
(최초 등록시 레포에서 조회한값이 null 이기때문에 404로 에러 던져짐)

그래서 로직 살~짝 수정되있으니 확인바랍니당

로컬에서  테스트는 완료했습니다.